### PR TITLE
Update OpenJDK Docker base image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8u66-b17-1-9
+FROM registry.opensource.zalan.do/stups/openjdk:8-26
 
 MAINTAINER Zalando SE
 


### PR DESCRIPTION
Update to latest Docker image stups openjdk                   8-26             24m ago stups_stups-go              NO_CVES_FOUND. This is just a "convenience" PR, ignore it if you want (but live with the CVEs) :smirk:
