### PR TITLE
#33 Create general protocol for bucket storage interfaces

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 
   :min-lein-version "2.0.0"
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.zalando.stups/friboo "1.6.0"]]
 
   :main ^:skip-aot org.zalando.stups.mint.worker.core

--- a/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
@@ -1,0 +1,11 @@
+(ns org.zalando.stups.mint.worker.external.bucket_storage)
+
+(defmacro StorageException
+  [msg data]
+  `(ex-info ~msg (merge ~data {:type "StorageException"})))
+
+(defprotocol BucketStorage
+  "Storage defines a protocol for writing user and client credentials to a bucket storage service like S3 or GCS"
+  (writable? [_ bucket-name app-id] "Check if bucket is writeable")
+  (save-user [_ bucket-name app-id username password] "Save user credentials in bucket")
+  (save-client [_ bucket-name app-id client-id client_secret] "Save client credentials in bucket"))

--- a/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
@@ -4,6 +4,9 @@
   [msg data]
   `(ex-info ~msg (merge ~data {:type "StorageException"})))
 
+(defn storage-exception? [e]
+  (= "StorageException" (:type (ex-data e))))
+
 (defprotocol BucketStorage
   "Storage defines a protocol for writing user and client credentials to a bucket storage service like S3 or GCS"
   (writable? [_ bucket-name app-id] "Check if bucket is writeable")

--- a/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
@@ -7,8 +7,20 @@
 (defn storage-exception? [e]
   (= "StorageException" (:type (ex-data e))))
 
-(defprotocol BucketStorage
-  "Storage defines a protocol for writing user and client credentials to a bucket storage service like S3 or GCS"
-  (writable? [_ bucket-name app-id] "Check if bucket is writeable")
-  (save-user [_ bucket-name app-id username password] "Save user credentials in bucket")
-  (save-client [_ bucket-name app-id client-id client_secret] "Save client credentials in bucket"))
+; TODO: actually infer the bucket type
+(defn infer-bucket-type
+  "infer bucket type from bucket name"
+  [bucket-name]
+  (if (.startsWith bucket-name "gs://") :gs :s3))
+
+(defmulti writable?
+          "Check if a bucket is writable?"
+          (fn [x] (infer-bucket-type (x :bucket-name))))
+
+(defmulti save-user
+          "Save user credentials in bucket"
+          (fn [x] (infer-bucket-type (x :bucket-name))))
+
+(defmulti save-client
+          "Save client credentials in bucket"
+          (fn [x] (infer-bucket-type (x :bucket-name))))

--- a/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
@@ -8,7 +8,6 @@
 (defn storage-exception? [e]
   (= "StorageException" (:type (ex-data e))))
 
-; TODO: actually infer the bucket type
 (defn infer-bucket-type
   "infer bucket type from bucket name"
   [bucket-name]
@@ -16,12 +15,14 @@
 
 (defmulti writable?
           "Check if a bucket is writable?"
-          (fn [x] (infer-bucket-type (x :bucket-name))))
+          (fn [bucket-name app-id &] (infer-bucket-type bucket-name)))
 
 (defmulti save-user
           "Save user credentials in bucket"
-          (fn [x] (infer-bucket-type (x :bucket-name))))
+          (fn [bucket-name app-id username password &]
+            (infer-bucket-type bucket-name)))
 
 (defmulti save-client
           "Save client credentials in bucket"
-          (fn [x] (infer-bucket-type (x :bucket-name))))
+          (fn [bucket-name app-id client-id client-secret &]
+            (infer-bucket-type bucket-name)))

--- a/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
@@ -1,4 +1,5 @@
-(ns org.zalando.stups.mint.worker.external.bucket_storage)
+(ns org.zalando.stups.mint.worker.external.bucket_storage
+  (:require [clojure.string :as str]))
 
 (defmacro StorageException
   [msg data]
@@ -11,7 +12,7 @@
 (defn infer-bucket-type
   "infer bucket type from bucket name"
   [bucket-name]
-  (if (.startsWith bucket-name "gs://") :gs :s3))
+  (if (str/starts-with? bucket-name "gs://") :gs :s3))
 
 (defmulti writable?
           "Check if a bucket is writable?"

--- a/src/org/zalando/stups/mint/worker/external/s3.clj
+++ b/src/org/zalando/stups/mint/worker/external/s3.clj
@@ -40,53 +40,43 @@
       (.setRegion s3client region))
     (.putObject s3client request)))
 
-(defmethod writable? :s3 [params]
-  {:pre [(not (str/blank? (params :bucket-name)))
-         (not (str/blank? (params :app-id)))]}
-  (let [bucket-name (params :bucket-name)
-        app-id (params :app-id)]
-    (try
-      (put-string bucket-name
-                  (str app-id "/test-mint-write")
-                  {:status "SUCCESS"})
-      (log/debug "S3 bucket %s with prefix %s is writable" bucket-name app-id)
-      true
-      (catch AmazonServiceException e
-        (log/debug "S3 bucket %s with prefix %s is NOT WRITABLE. Reason %s." bucket-name app-id (str e))
-        false))))
+(defmethod writable? :s3 [bucket-name app-id]
+  {:pre [(not (str/blank? bucket-name))
+         (not (str/blank? app-id))]}
+  (try
+    (put-string bucket-name
+                (str app-id "/test-mint-write")
+                {:status "SUCCESS"})
+    (log/debug "S3 bucket %s with prefix %s is writable" bucket-name app-id)
+    true
+    (catch AmazonServiceException e
+      (log/debug "S3 bucket %s with prefix %s is NOT WRITABLE. Reason %s." bucket-name app-id (str e))
+      false)))
 
-(defmethod save-user :s3 [params]
-  {:pre [(not (str/blank? (params :bucket-name)))
-         (not (str/blank? (params :app-id)))]}
-  (let [bucket-name (params :bucket-name)
-        app-id (params :app-id)
-        username (params :username)
-        password (params :password)]
-    (try
-      (put-string bucket-name
-                  (str app-id "/user.json")
-                  {:application_username username
-                   :application_password password})
-      (catch AmazonServiceException e
-        (StorageException (.getMessage e)
-                          {:status   (.getStatusCode e)
-                           :message  (.getMessage e)
-                           :original e})))))
+(defmethod save-user :s3 [bucket-name app-id username password]
+  {:pre [(not (str/blank? bucket-name))
+         (not (str/blank? app-id))]}
+  (try
+    (put-string bucket-name
+                (str app-id "/user.json")
+                {:application_username username
+                 :application_password password})
+    (catch AmazonServiceException e
+      (StorageException (.getMessage e)
+                        {:status   (.getStatusCode e)
+                         :message  (.getMessage e)
+                         :original e}))))
 
-(defmethod save-client :s3 [params]
-  {:pre [(not (str/blank? (params :bucket-name)))
-         (not (str/blank? (params :app-id)))]}
-  (let [bucket-name (params :bucket-name)
-        app-id (params :app-id)
-        client-id (params :client-id)
-        client-secret (params :client-secret)]
-    (try
-      (put-string bucket-name
-                  (str app-id "/client.json")
-                  {:client_id     client-id
-                   :client_secret client-secret})
-      (catch AmazonServiceException e
-        (StorageException (.getMessage e)
-                          {:status   (.getStatusCode e)
-                           :message  (.getMessage e)
-                           :original e})))))
+(defmethod save-client :s3 [bucket-name app-id client-id client-secret]
+  {:pre [(not (str/blank? bucket-name))
+         (not (str/blank? app-id))]}
+  (try
+    (put-string bucket-name
+                (str app-id "/client.json")
+                {:client_id     client-id
+                 :client_secret client-secret})
+    (catch AmazonServiceException e
+      (StorageException (.getMessage e)
+                        {:status   (.getStatusCode e)
+                         :message  (.getMessage e)
+                         :original e}))))

--- a/src/org/zalando/stups/mint/worker/external/s3.clj
+++ b/src/org/zalando/stups/mint/worker/external/s3.clj
@@ -2,7 +2,9 @@
   (:require [cheshire.core :as json]
             [org.zalando.stups.friboo.log :as log]
             [clojure.string :as str]
-            [org.zalando.stups.mint.worker.external.bucket_storage :refer [BucketStorage
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [writable?
+                                                                           save-user
+                                                                           save-client
                                                                            StorageException]])
   (:import (java.io ByteArrayInputStream)
            (com.amazonaws AmazonServiceException)
@@ -22,27 +24,27 @@
 (defn put-string
   "Stores an object in S3."
   [bucket-name path data]
-  (let [region   (infer-region bucket-name)
+  (let [region (infer-region bucket-name)
         s3client (AmazonS3Client.)
-        bytes    (-> data
-                 (json/generate-string)
-                 (.getBytes "UTF-8"))
-        stream   (ByteArrayInputStream. bytes)
+        bytes (-> data
+                  (json/generate-string)
+                  (.getBytes "UTF-8"))
+        stream (ByteArrayInputStream. bytes)
         metadata (doto (ObjectMetadata.)
                    (.setContentLength (count bytes))
                    (.setContentType "application/json"))
-        request  (doto (PutObjectRequest. bucket-name path stream metadata)
-                   (.withCannedAcl CannedAccessControlList/BucketOwnerFullControl))]
+        request (doto (PutObjectRequest. bucket-name path stream metadata)
+                  (.withCannedAcl CannedAccessControlList/BucketOwnerFullControl))]
     ; to get rid of the S3V4AuthErrorRetryStrategy warnings
     (when region
       (.setRegion s3client region))
     (.putObject s3client request)))
 
-(defrecord S3 []
-  BucketStorage
-  (writable? [_ bucket-name app-id]
-    {:pre [(not (str/blank? bucket-name))
-           (not (str/blank? app-id))]}
+(defmethod writable? :s3 [params]
+  {:pre [(not (str/blank? (params :bucket-name)))
+         (not (str/blank? (params :app-id)))]}
+  (let [bucket-name (params :bucket-name)
+        app-id (params :app-id)]
     (try
       (put-string bucket-name
                   (str app-id "/test-mint-write")
@@ -51,11 +53,15 @@
       true
       (catch AmazonServiceException e
         (log/debug "S3 bucket %s with prefix %s is NOT WRITABLE. Reason %s." bucket-name app-id (str e))
-        false)))
+        false))))
 
-  (save-user [_ bucket-name app-id username password]
-    {:pre [(not (str/blank? bucket-name))
-           (not (str/blank? app-id))]}
+(defmethod save-user :s3 [params]
+  {:pre [(not (str/blank? (params :bucket-name)))
+         (not (str/blank? (params :app-id)))]}
+  (let [bucket-name (params :bucket-name)
+        app-id (params :app-id)
+        username (params :username)
+        password (params :password)]
     (try
       (put-string bucket-name
                   (str app-id "/user.json")
@@ -63,20 +69,24 @@
                    :application_password password})
       (catch AmazonServiceException e
         (StorageException (.getMessage e)
-                     {:status (.getStatusCode e)
-                      :message (.getMessage e)
-                      :original e}))))
+                          {:status   (.getStatusCode e)
+                           :message  (.getMessage e)
+                           :original e})))))
 
-  (save-client [_ bucket-name app-id client-id client_secret]
-    {:pre [(not (str/blank? bucket-name))
-           (not (str/blank? app-id))]}
+(defmethod save-client :s3 [params]
+  {:pre [(not (str/blank? (params :bucket-name)))
+         (not (str/blank? (params :app-id)))]}
+  (let [bucket-name (params :bucket-name)
+        app-id (params :app-id)
+        client-id (params :client-id)
+        client-secret (params :client-secret)]
     (try
       (put-string bucket-name
                   (str app-id "/client.json")
-                  {:client_id client-id
-                   :client_secret client_secret})
+                  {:client_id     client-id
+                   :client_secret client-secret})
       (catch AmazonServiceException e
         (StorageException (.getMessage e)
-                     {:status (.getStatusCode e)
-                      :message (.getMessage e)
-                      :original e})))))
+                          {:status   (.getStatusCode e)
+                           :message  (.getMessage e)
+                           :original e})))))

--- a/src/org/zalando/stups/mint/worker/job/run.clj
+++ b/src/org/zalando/stups/mint/worker/job/run.clj
@@ -6,7 +6,7 @@
             [org.zalando.stups.mint.worker.external.storage :as storage]
             [org.zalando.stups.mint.worker.external.apps :as apps]
             [org.zalando.stups.mint.worker.external.etcd :as etcd]
-            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.s3]
             [org.zalando.stups.mint.worker.external.bucket_storage :refer [storage-exception?]]
             [overtone.at-at :refer [every]]
             [clj-time.core :as time]))

--- a/src/org/zalando/stups/mint/worker/job/run.clj
+++ b/src/org/zalando/stups/mint/worker/job/run.clj
@@ -7,6 +7,7 @@
             [org.zalando.stups.mint.worker.external.apps :as apps]
             [org.zalando.stups.mint.worker.external.etcd :as etcd]
             [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [storage-exception?]]
             [overtone.at-at :refer [every]]
             [clj-time.core :as time]))
 
@@ -21,9 +22,6 @@
 (def rate-limited-until (atom (time/epoch)))
 
 (def worker-id (java.util.UUID/randomUUID))
-
-(defn storage-exception? [e]
-  (= "StorageException" (:type (ex-data e))))
 
 (defn run-sync
   "Creates and deletes applications, rotates and distributes their credentials."

--- a/src/org/zalando/stups/mint/worker/job/run.clj
+++ b/src/org/zalando/stups/mint/worker/job/run.clj
@@ -47,7 +47,7 @@
                   kio-app (get kio-apps-by-id app-id)]
               (when (or (not etcd-lock-url) (etcd/refresh-lock etcd-lock-url worker-id etcd-lock-ttl))
               (try
-                (sync-app (s3/->S3) configuration
+                (sync-app configuration
                           mint-app
                           kio-app
                           tokens)

--- a/src/org/zalando/stups/mint/worker/job/sync_app.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_app.clj
@@ -2,7 +2,8 @@
   (:require [org.zalando.stups.friboo.log :as log]
             [org.zalando.stups.friboo.config :as config]
             [org.zalando.stups.mint.worker.external.storage :as storage]
-            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [writable?
+                                                                           StorageException]]
             [org.zalando.stups.mint.worker.job.sync-client :refer [sync-client]]
             [org.zalando.stups.mint.worker.job.sync-user :refer [sync-user]]
             [org.zalando.stups.mint.worker.job.sync-password :refer [sync-password]]
@@ -10,7 +11,7 @@
 
 (defn sync-app
   "Syncs the application with the given app-id."
-  [{:keys [max-s3-errors] :as configuration} {:keys [id s3_errors]} kio-app tokens]
+  [backend {:keys [max-s3-errors] :as configuration} {:keys [id s3_errors]} kio-app tokens]
   {:pre [(not (str/blank? id))]}
   (let [storage-url (config/require-config configuration :mint-storage-url)
         kio-url (config/require-config configuration :kio-url)]
@@ -19,27 +20,27 @@
     (if-not (> s3_errors
                max-s3-errors)
             (let [app        (storage/get-app storage-url id tokens)
-                  unwritable (doall (remove #(s3/writable? % id) (:s3_buckets app)))]
+                  unwritable (doall (remove #(writable? backend % id) (:s3_buckets app)))]
               (if (seq unwritable)
                   ; unwritable buckets! skip sync.
                   (do
-                    (log/debug "Skipping sync for app %s because there are unwritable S3 buckets: %s" id unwritable)
+                    (log/debug "Skipping sync for app %s because there are unwritable buckets: %s" id unwritable)
                     ; now throw exception so that it will be handled in run.clj
-                    (throw (s3/S3Exception (str "Unwritable S3 buckets: "
+                    (throw (StorageException (str "Unwritable buckets: "
                                                 (pr-str unwritable))
                                            {:s3_buckets unwritable})))
                   ; writable buckets, presumably. do sync.
                   ; TODO handle nil for kio-app
-                  (let [app (merge app (sync-user app kio-app configuration tokens))]
+                  (let [app (merge app (sync-user backend app kio-app configuration tokens))]
                     (log/debug "App has mint configuration %s" app)
                     (log/debug "App has kio configuration %s" kio-app)
                     (if (:active kio-app)
                       (do
-                        (sync-password app configuration tokens)
+                        (sync-password backend app configuration tokens)
                         (if (:is_client_confidential app)
-                          (sync-client app configuration tokens)
+                          (sync-client backend app configuration tokens)
                           (log/debug "Skipping client rotation for non-confidential client %s" id)))
                       (log/debug "Skipping password and client rotation for inactive app %s" id))
                     (log/info "Synced app %s." id))))
             ; else
-            (log/debug "Skipping sync for app %s because could not write to S3 repeatedly" id))))
+            (log/debug "Skipping sync for app %s because could not write to bucket storage repeatedly" id))))

--- a/src/org/zalando/stups/mint/worker/job/sync_app.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_app.clj
@@ -20,8 +20,7 @@
     (if-not (> s3_errors
                max-s3-errors)
             (let [app        (storage/get-app storage-url id tokens)
-                  params {:app-id id}
-                  unwritable (doall (remove #(writable? (assoc params :bucket-name %)) (:s3_buckets app)))]
+                  unwritable (doall (remove #(writable? % id) (:s3_buckets app)))]
               (if (seq unwritable)
                   ; unwritable buckets! skip sync.
                   (do

--- a/src/org/zalando/stups/mint/worker/job/sync_client.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_client.clj
@@ -26,11 +26,10 @@
           (let [generate-client-response (services/generate-new-client service-user-url username client_id tokens)
                 new-client-id (:client_id generate-client-response)
                 transaction-id (:txid generate-client-response)
-                client-secret (:client_secret generate-client-response)
-                params {:app-id id, :client-id new-client-id, :client-secret client-secret}]
+                client-secret (:client_secret generate-client-response)]
             ; Step 2: distribute it
             (log/debug "Saving the new client for %s to buckets: %s..." id s3_buckets)
-            (if-let [error (c/has-error (c/busy-map #(save-client (assoc params :bucket-name %))
+            (if-let [error (c/has-error (c/busy-map #(save-client % id new-client-id client-secret)
                                                     s3_buckets))]
               (do
                 (log/debug "Could not save client to bucket: %s" (str error))

--- a/src/org/zalando/stups/mint/worker/job/sync_client.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_client.clj
@@ -5,12 +5,12 @@
             [org.zalando.stups.mint.worker.job.common :as c]
             [org.zalando.stups.mint.worker.external.services :as services]
             [org.zalando.stups.mint.worker.external.storage :as storage]
-            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [save-client]]
             [clojure.string :as str]))
 
 (defn sync-client
   "If neccessary, creates and syncs new client credentials for the given app"
-  [{:keys [id client_id username s3_buckets last_client_rotation]} configuration tokens]
+  [backend {:keys [id client_id username s3_buckets last_client_rotation]} configuration tokens]
   {:pre [(not (str/blank? id))
          (seq s3_buckets)
          (not (str/blank? username))]}
@@ -28,8 +28,8 @@
                 transaction-id (:txid generate-client-response)
                 client-secret (:client_secret generate-client-response)]
             ; Step 2: distribute it
-            (log/debug "Saving the new client for %s to S3 buckets: %s..." id s3_buckets)
-            (if-let [error (c/has-error (c/busy-map #(s3/save-client % id new-client-id client-secret)
+            (log/debug "Saving the new client for %s to buckets: %s..." id s3_buckets)
+            (if-let [error (c/has-error (c/busy-map #(save-client backend % id new-client-id client-secret)
                                                     s3_buckets))]
               (do
                 (log/debug "Could not save client to bucket: %s" (str error))

--- a/src/org/zalando/stups/mint/worker/job/sync_password.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_password.clj
@@ -5,12 +5,12 @@
             [org.zalando.stups.mint.worker.job.common :as c]
             [org.zalando.stups.mint.worker.external.services :as services]
             [org.zalando.stups.mint.worker.external.storage :as storage]
-            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [save-user]]
             [clojure.string :as str]))
 
 (defn sync-password
   "If neccessary, creates and syncs a new password for the given app."
-  [{:keys [id username last_password_rotation s3_buckets]} configuration tokens]
+  [backend {:keys [id username last_password_rotation s3_buckets]} configuration tokens]
   {:pre [(not (str/blank? id))
          (seq s3_buckets)
          (not (str/blank? username))]}
@@ -25,8 +25,8 @@
         (log/debug "Acquiring new password for %s..." username)
         (let [{:keys [password txid]} (services/generate-new-password service-user-url username tokens)]
           ; Step 2: distribute it
-          (log/debug "Saving the new password for %s to S3 buckets: %s..." id s3_buckets)
-          (if-let [error (c/has-error (c/busy-map #(s3/save-user % id username password)
+          (log/debug "Saving the new password for %s to buckets: %s..." id s3_buckets)
+          (if-let [error (c/has-error (c/busy-map #(save-user backend % id username password)
                                                   s3_buckets))]
             (do
               (log/debug "Could not save password to bucket: %s" (str error))

--- a/src/org/zalando/stups/mint/worker/job/sync_password.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_password.clj
@@ -23,11 +23,10 @@
       (do
         ; Step 1: generate password
         (log/debug "Acquiring new password for %s..." username)
-        (let [{:keys [password txid]} (services/generate-new-password service-user-url username tokens)
-              params {:app-id id :username username :password password}]
+        (let [{:keys [password txid]} (services/generate-new-password service-user-url username tokens)]
           ; Step 2: distribute it
           (log/debug "Saving the new password for %s to buckets: %s..." id s3_buckets)
-          (if-let [error (c/has-error (c/busy-map #(save-user (assoc params :bucket-name %))
+          (if-let [error (c/has-error (c/busy-map #(save-user % id username password)
                                                   s3_buckets))]
             (do
               (log/debug "Could not save password to bucket: %s" (str error))

--- a/src/org/zalando/stups/mint/worker/job/sync_user.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_user.clj
@@ -57,13 +57,12 @@
                                                                           :confidential  is_client_confidential}
                                                           :user_config   {:scopes (:application-scope scopes)}}
                                                          tokens)
-                new-client-id (:client_id response)
-                params {:app-id id :client-id new-client-id :client-secret nil}]
+                new-client-id (:client_id response)]
 
             (when (and (not is_client_confidential)
                        (nil? client_id))
               (log/debug "Saving non-confidential client ID %s for app %s..." new-client-id id)
-              (when-let [error (c/has-error (c/busy-map #(save-client (assoc params :bucket-name %))
+              (when-let [error (c/has-error (c/busy-map #(save-client % id new-client-id nil)
                                                         s3_buckets))]
                 (log/debug "Could not save client ID: %s" (str error))
                 ; throw to update s3_errors once outside

--- a/src/org/zalando/stups/mint/worker/job/sync_user.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_user.clj
@@ -5,12 +5,12 @@
             [org.zalando.stups.mint.worker.job.common :as c]
             [org.zalando.stups.mint.worker.external.services :as services]
             [org.zalando.stups.mint.worker.external.storage :as storage]
-            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [save-client]]
             [clojure.string :as str]))
 
 (defn sync-user
   "If neccessary, creates or deletes service users."
-  [{:keys [id username s3_buckets last_synced last_modified scopes redirect_url is_client_confidential client_id] :as app}
+  [backend {:keys [id username s3_buckets last_synced last_modified scopes redirect_url is_client_confidential client_id] :as app}
    {:keys [team_id active name subtitle]} ; kio app
    configuration
    tokens]
@@ -62,7 +62,7 @@
             (when (and (not is_client_confidential)
                        (nil? client_id))
               (log/debug "Saving non-confidential client ID %s for app %s..." new-client-id id)
-              (when-let [error (c/has-error (c/busy-map #(s3/save-client % id new-client-id nil)
+              (when-let [error (c/has-error (c/busy-map #(save-client backend % id new-client-id nil)
                                                         s3_buckets))]
                 (log/debug "Could not save client ID: %s" (str error))
                 ; throw to update s3_errors once outside

--- a/test/org/zalando/stups/mint/worker/external/bucket_storage_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/bucket_storage_test.clj
@@ -1,0 +1,12 @@
+(ns org.zalando.stups.mint.worker.external.bucket_storage-test
+  (:require [clojure.test :refer :all]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [infer-bucket-type]]))
+
+; bucket type should be gs if prefixed with a gs:// scheme.
+(deftest infer-bucket-type-gs
+  (is (= (infer-bucket-type "gs://prefix-is-gs") :gs)))
+
+; bucket type should be :s3 in all other cases.
+(deftest infer-bucket-type-s3
+  (is (= (infer-bucket-type "any-name-is-s3") :s3))
+  (is (= (infer-bucket-type "s3://any-name-is-s3") :s3)))

--- a/test/org/zalando/stups/mint/worker/external/s3_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/s3_test.clj
@@ -13,23 +13,36 @@
 
 (deftest s3-writable-false
   (with-redefs [s3/put-string mock-put-error]
-    (is (= (writable? (s3/->S3) "bucket" "app")
+    (is (= (writable? {:bucket-name "bucket", :app-id "app"})
            false))))
 
 (deftest s3-writable-true
   (with-redefs [s3/put-string (constantly nil)]
-    (is (= (writable? (s3/->S3) "bucket" "app")
+    (is (= (writable? {:bucket-name "bucket", :app-id "app"})
            true))))
 
 (deftest s3-save-client-fail
   (with-redefs [s3/put-string mock-put-error]
-    (let [error (save-client (s3/->S3) "bucket" "app" "client" "secret")]
+    (let [error (save-client {:bucket-name "bucket"
+                              :app-id "app"
+                              :client-id "client"
+                              :client-secret"secret"})]
       (is (= (:type (ex-data error))
              "StorageException")))))
 
+(deftest s3-save-client-success
+  (with-redefs [s3/put-string (constantly nil)]
+    (is (nil? (save-client {:bucket-name "bucket"
+                            :app-id "app"
+                            :client-id "client"
+                            :client-secret"secret"})))))
+
 (deftest s3-save-user-fail
   (with-redefs [s3/put-string mock-put-error]
-    (let [error (save-user (s3/->S3) "bucket" "app" "name" "password")]
+    (let [error (save-user {:bucket-name "bucket"
+                            :app-id "app"
+                            :name "name"
+                            :password "password"})]
       (is (= (:type (ex-data error))
              "StorageException")))))
 

--- a/test/org/zalando/stups/mint/worker/external/s3_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/s3_test.clj
@@ -1,6 +1,9 @@
 (ns org.zalando.stups.mint.worker.external.s3-test
   (:require [clojure.test :refer :all]
-            [org.zalando.stups.mint.worker.external.s3 :as s3])
+            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [save-client
+                                                                           save-user
+                                                                           writable?]])
   (:import (com.amazonaws AmazonServiceException)
            (com.amazonaws.regions Region Regions)))
 
@@ -10,25 +13,25 @@
 
 (deftest s3-writable-false
   (with-redefs [s3/put-string mock-put-error]
-    (is (= (s3/writable? "bucket" "app")
+    (is (= (writable? (s3/->S3) "bucket" "app")
            false))))
 
 (deftest s3-writable-true
   (with-redefs [s3/put-string (constantly nil)]
-    (is (= (s3/writable? "bucket" "app")
+    (is (= (writable? (s3/->S3) "bucket" "app")
            true))))
 
 (deftest s3-save-client-fail
   (with-redefs [s3/put-string mock-put-error]
-    (let [error (s3/save-client "bucket" "app" "client" "secret")]
+    (let [error (save-client (s3/->S3) "bucket" "app" "client" "secret")]
       (is (= (:type (ex-data error))
-             "S3Exception")))))
+             "StorageException")))))
 
 (deftest s3-save-user-fail
   (with-redefs [s3/put-string mock-put-error]
-    (let [error (s3/save-user "bucket" "app" "name" "password")]
+    (let [error (save-user (s3/->S3) "bucket" "app" "name" "password")]
       (is (= (:type (ex-data error))
-             "S3Exception")))))
+             "StorageException")))))
 
 (deftest infer-ireland-region
   (is (= (s3/infer-region "a-mint-bucket-in-eu-west-1")

--- a/test/org/zalando/stups/mint/worker/external/s3_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/s3_test.clj
@@ -13,36 +13,27 @@
 
 (deftest s3-writable-false
   (with-redefs [s3/put-string mock-put-error]
-    (is (= (writable? {:bucket-name "bucket", :app-id "app"})
+    (is (= (writable? "bucket" "app")
            false))))
 
 (deftest s3-writable-true
   (with-redefs [s3/put-string (constantly nil)]
-    (is (= (writable? {:bucket-name "bucket", :app-id "app"})
+    (is (= (writable? "bucket" "app")
            true))))
 
 (deftest s3-save-client-fail
   (with-redefs [s3/put-string mock-put-error]
-    (let [error (save-client {:bucket-name "bucket"
-                              :app-id "app"
-                              :client-id "client"
-                              :client-secret"secret"})]
+    (let [error (save-client "bucket" "app" "client" "secret")]
       (is (= (:type (ex-data error))
              "StorageException")))))
 
 (deftest s3-save-client-success
   (with-redefs [s3/put-string (constantly nil)]
-    (is (nil? (save-client {:bucket-name "bucket"
-                            :app-id "app"
-                            :client-id "client"
-                            :client-secret"secret"})))))
+    (is (nil? (save-client "bucket" "app" "client" "secret")))))
 
 (deftest s3-save-user-fail
   (with-redefs [s3/put-string mock-put-error]
-    (let [error (save-user {:bucket-name "bucket"
-                            :app-id "app"
-                            :name "name"
-                            :password "password"})]
+    (let [error (save-user "bucket" "app" "name" "password")]
       (is (= (:type (ex-data error))
              "StorageException")))))
 

--- a/test/org/zalando/stups/mint/worker/job/run_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/run_test.clj
@@ -3,7 +3,6 @@
             [org.zalando.stups.mint.worker.test-helpers :refer [throwing
                                                                 track
                                                                 third
-                                                                fourth
                                                                 test-tokens
                                                                 one?
                                                                 test-config]]
@@ -86,7 +85,7 @@
       (is (one? (count (:sync @calls))))
       (is (zero? (count (:delete @calls))))
       (let [call-param (first (:sync @calls))
-            kio-app (fourth call-param)]
+            kio-app (third call-param)]
         (is (= test-kio-app
                kio-app))))))
 

--- a/test/org/zalando/stups/mint/worker/job/sync_app_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/sync_app_test.clj
@@ -7,6 +7,7 @@
                                                                 test-tokens
                                                                 test-config]]
             [org.zalando.stups.mint.worker.external.storage :as storage]
+            [org.zalando.stups.mint.worker.external.s3 :as s3]
             [org.zalando.stups.mint.worker.external.bucket_storage :refer [writable?]]
             [org.zalando.stups.mint.worker.job.sync-app :refer [sync-app]]
             [org.zalando.stups.mint.worker.job.sync-client :refer [sync-client]]
@@ -31,7 +32,7 @@
   (let [calls (atom {})]
     (with-redefs [storage/get-app (track calls :mint-config)
                   writable? (track calls :writable)]
-      (sync-app nil test-config
+      (sync-app test-config
                 (assoc test-app :s3_errors 11)
                 test-kio-app
                 test-tokens)
@@ -45,7 +46,7 @@
                   storage/get-app (constantly test-app-details)
                   storage/update-status (track calls :update)]
       (try
-        (sync-app nil test-config
+        (sync-app test-config
                   test-app
                   test-kio-app
                   test-tokens)
@@ -60,11 +61,11 @@
         kio-app {:id "kio"
                  :active false}]
     (with-redefs [storage/get-app (constantly test-app-details)
-                  writable? (constantly true)
+                  s3/put-string (constantly nil)
                   sync-user (constantly test-app)
                   sync-client (track calls :client)
                   sync-password (track calls :password)]
-      (sync-app nil test-config
+      (sync-app test-config
                 test-app
                 (assoc test-kio-app :active false)
                 test-tokens)
@@ -78,11 +79,11 @@
         kio-app {:id "kio"
                  :active true}]
     (with-redefs [storage/get-app (constantly test-app-details)
-                  writable? (constantly true)
+                  s3/put-string (constantly nil)
                   sync-user (constantly test-app-details)
                   sync-client (track calls :client)
                   sync-password (track calls :password)]
-      (sync-app nil test-config
+      (sync-app test-config
                 test-app
                 test-kio-app
                 test-tokens)
@@ -96,11 +97,11 @@
         kio-app {:id "kio"
                  :active true}]
     (with-redefs [storage/get-app (constantly test-app-details)
-                  writable? (constantly true)
+                  s3/put-string (constantly nil)
                   sync-user (constantly test-app-details)
                   sync-client (track calls :client)
                   sync-password (track calls :password)]
-      (sync-app nil test-config
+      (sync-app test-config
                 test-app
                 test-kio-app
                 test-tokens)
@@ -110,8 +111,8 @@
 ; errors are handled by calling function
 (deftest do-not-handle-errors
   (with-redefs [storage/get-app (throwing "ups")
-                writable? (constantly true)]
-    (is (thrown? Exception (sync-app nil test-config
+                s3/put-string (constantly nil)]
+    (is (thrown? Exception (sync-app test-config
                                      test-app
                                      test-kio-app
                                      test-tokens)))))

--- a/test/org/zalando/stups/mint/worker/job/sync_app_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/sync_app_test.clj
@@ -7,7 +7,7 @@
                                                                 test-tokens
                                                                 test-config]]
             [org.zalando.stups.mint.worker.external.storage :as storage]
-            [org.zalando.stups.mint.worker.external.s3 :as s3]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [writable?]]
             [org.zalando.stups.mint.worker.job.sync-app :refer [sync-app]]
             [org.zalando.stups.mint.worker.job.sync-client :refer [sync-client]]
             [org.zalando.stups.mint.worker.job.sync-user :refer [sync-user]]
@@ -30,8 +30,8 @@
 (deftest do-nothing-when-max-errors-exceeded
   (let [calls (atom {})]
     (with-redefs [storage/get-app (track calls :mint-config)
-                  s3/writable? (track calls :writable)]
-      (sync-app test-config
+                  writable? (track calls :writable)]
+      (sync-app nil test-config
                 (assoc test-app :s3_errors 11)
                 test-kio-app
                 test-tokens)
@@ -41,11 +41,11 @@
 ; it should throw when at least one bucket is not writable
 (deftest throw-when-no-writable-bucket
   (let [calls (atom {})]
-    (with-redefs [s3/writable? (sequentially true false)
+    (with-redefs [writable? (sequentially true false)
                   storage/get-app (constantly test-app-details)
                   storage/update-status (track calls :update)]
       (try
-        (sync-app test-config
+        (sync-app nil test-config
                   test-app
                   test-kio-app
                   test-tokens)
@@ -60,11 +60,11 @@
         kio-app {:id "kio"
                  :active false}]
     (with-redefs [storage/get-app (constantly test-app-details)
-                  s3/writable? (constantly true)
+                  writable? (constantly true)
                   sync-user (constantly test-app)
                   sync-client (track calls :client)
                   sync-password (track calls :password)]
-      (sync-app test-config
+      (sync-app nil test-config
                 test-app
                 (assoc test-kio-app :active false)
                 test-tokens)
@@ -78,11 +78,11 @@
         kio-app {:id "kio"
                  :active true}]
     (with-redefs [storage/get-app (constantly test-app-details)
-                  s3/writable? (constantly true)
+                  writable? (constantly true)
                   sync-user (constantly test-app-details)
                   sync-client (track calls :client)
                   sync-password (track calls :password)]
-      (sync-app test-config
+      (sync-app nil test-config
                 test-app
                 test-kio-app
                 test-tokens)
@@ -96,11 +96,11 @@
         kio-app {:id "kio"
                  :active true}]
     (with-redefs [storage/get-app (constantly test-app-details)
-                  s3/writable? (constantly true)
+                  writable? (constantly true)
                   sync-user (constantly test-app-details)
                   sync-client (track calls :client)
                   sync-password (track calls :password)]
-      (sync-app test-config
+      (sync-app nil test-config
                 test-app
                 test-kio-app
                 test-tokens)
@@ -110,8 +110,8 @@
 ; errors are handled by calling function
 (deftest do-not-handle-errors
   (with-redefs [storage/get-app (throwing "ups")
-                s3/writable? (constantly true)]
-    (is (thrown? Exception (sync-app test-config
+                writable? (constantly true)]
+    (is (thrown? Exception (sync-app nil test-config
                                      test-app
                                      test-kio-app
                                      test-tokens)))))

--- a/test/org/zalando/stups/mint/worker/job/sync_client_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/sync_client_test.clj
@@ -34,7 +34,7 @@
         test-app (assoc test-app :last_client_rotation recently)
         calls (atom {})]
     (with-redefs [services/generate-new-client (track calls :gen)]
-      (sync-client nil test-app
+      (sync-client test-app
                    test-config
                    test-tokens)
       (is (= 0 (count (:gen @calls)))))))
@@ -49,7 +49,7 @@
                   save-client (constantly (PutObjectResult.))
                   services/commit-client (track calls :commit)
                   storage/update-status (track calls :update)]
-      (sync-client nil test-app
+      (sync-client test-app
                    test-config
                    test-tokens)
       (is (= 1 (count (:commit @calls))))
@@ -68,7 +68,7 @@
                   save-client (constantly (PutObjectResult.))
                   services/commit-client (track calls :commit)
                   storage/update-status (track calls :update)]
-      (sync-client nil test-app
+      (sync-client test-app
                    test-config
                    test-tokens)
       (is (= 1 (count (:commit @calls))))
@@ -82,7 +82,7 @@
                   services/commit-client (track calls :commit)
                   storage/update-status (track calls :update)]
       (try
-        (sync-client nil test-app
+        (sync-client test-app
                      test-config
                      test-tokens)
         (is false)
@@ -95,6 +95,6 @@
 ; it should not handle errors
 (deftest do-not-handle-errors
   (with-redefs [services/generate-new-client (throwing "ups")]
-    (is (thrown? Exception (sync-client nil test-app
+    (is (thrown? Exception (sync-client test-app
                                         test-config
                                         test-tokens)))))

--- a/test/org/zalando/stups/mint/worker/job/sync_password_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/sync_password_test.clj
@@ -31,7 +31,7 @@
         test-app (assoc test-app :last_password_rotation recently)
         calls (atom {})]
     (with-redefs [services/generate-new-password (track calls :gen)]
-      (sync-password nil test-app
+      (sync-password test-app
                      test-config
                      test-tokens)
       (is (= 0 (count (:gen @calls)))))))
@@ -43,7 +43,7 @@
                   save-user (constantly (PutObjectResult.))
                   services/commit-password (track calls :commit)
                   storage/update-status (track calls :update)]
-      (sync-password nil test-app
+      (sync-password test-app
                      test-config
                      test-tokens)
       (is (= 1 (count (:commit @calls))))
@@ -65,7 +65,7 @@
                   save-user (constantly (PutObjectResult.))
                   services/commit-password (track calls :commit)
                   storage/update-status (track calls :update)]
-      (sync-password nil test-app
+      (sync-password test-app
                      test-config
                      test-tokens)
       (is (= 1 (count (:commit @calls))))
@@ -79,7 +79,7 @@
                   services/commit-password (track calls :commit)
                   storage/update-status (track calls :update)]
       (try
-        (sync-password nil test-app
+        (sync-password test-app
                        test-config
                        test-tokens)
         (is false)
@@ -95,7 +95,7 @@
     (with-redefs [services/generate-new-password (throwing "whoopsie daisy")
                   services/commit-password (track calls :commit)
                   storage/update-status (track calls :update)]
-      (is (thrown? Exception (sync-password nil test-app
+      (is (thrown? Exception (sync-password test-app
                                             test-config
                                             test-tokens)))
       (is (= 0 (count (:commit @calls))))

--- a/test/org/zalando/stups/mint/worker/job/sync_user_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/sync_user_test.clj
@@ -34,7 +34,7 @@
     (with-redefs [services/list-users (constantly [])
                   services/delete-user (track calls :delete)
                   services/create-or-update-user (track calls :update)]
-      (sync-user nil test-app
+      (sync-user test-app
                  test-kio-app
                  test-config
                  test-tokens)
@@ -49,7 +49,7 @@
                                                     :id (:username test-app)}])
                   services/delete-user (track calls :delete)
                   services/create-or-update-user (track calls :update)]
-      (sync-user nil test-app
+      (sync-user test-app
                  test-kio-app
                  test-config
                  test-tokens)
@@ -66,7 +66,7 @@
                                  :last_synced (c/format-date-time now))
         calls (atom {})]
     (with-redefs [services/create-or-update-user (track calls :update)]
-      (sync-user nil test-app
+      (sync-user test-app
                  test-kio-app
                  test-config
                  test-tokens)
@@ -79,7 +79,7 @@
                                                                              (time/minutes 3))))
         calls (atom {})]
     (with-redefs [services/create-or-update-user (track calls :update)]
-      (sync-user nil test-app
+      (sync-user test-app
                  test-kio-app
                  test-config
                  test-tokens)
@@ -93,7 +93,7 @@
                                                    (apply (track calls :update-user) args)
                                                    test-response)
                   storage/update-status (track calls :update-status)]
-      (let [returned-app (sync-user nil test-app
+      (let [returned-app (sync-user test-app
                                     test-kio-app
                                     test-config
                                     test-tokens)]
@@ -108,7 +108,7 @@
     (with-redefs [services/create-or-update-user (constantly test-response)
                   save-client (constantly (PutObjectResult.))
                   storage/update-status (track calls :update)]
-      (let [app (sync-user nil test-app
+      (let [app (sync-user test-app
                            test-kio-app
                            test-config
                            test-tokens)]
@@ -124,7 +124,7 @@
                   save-client (sequentially (PutObjectResult.) (StorageException "bad s3" {}))
                   storage/update-status (track calls :update)]
       (try
-        (sync-user nil test-app
+        (sync-user test-app
                    test-kio-app
                    test-config
                    test-tokens)

--- a/test/org/zalando/stups/mint/worker/job/sync_user_test.clj
+++ b/test/org/zalando/stups/mint/worker/job/sync_user_test.clj
@@ -10,6 +10,7 @@
             [org.zalando.stups.mint.worker.job.common :as c]
             [org.zalando.stups.mint.worker.external.services :as services]
             [org.zalando.stups.mint.worker.external.storage :as storage]
+            [org.zalando.stups.mint.worker.external.s3 :as s3]
             [org.zalando.stups.mint.worker.external.bucket_storage :refer [save-client
                                                                            StorageException]])
   (:import (com.amazonaws.services.s3.model PutObjectResult)))
@@ -106,7 +107,7 @@
   (let [test-app (assoc test-app :is_client_confidential false)
         calls (atom {})]
     (with-redefs [services/create-or-update-user (constantly test-response)
-                  save-client (constantly (PutObjectResult.))
+                  s3/put-string (constantly (PutObjectResult.))
                   storage/update-status (track calls :update)]
       (let [app (sync-user test-app
                            test-kio-app
@@ -121,7 +122,7 @@
   (let [test-app (assoc test-app :is_client_confidential false)
         calls (atom {})]
     (with-redefs [services/create-or-update-user (constantly test-response)
-                  save-client (sequentially (PutObjectResult.) (StorageException "bad s3" {}))
+                  s3/put-string (sequentially (PutObjectResult.) (StorageException "bad s3" {}))
                   storage/update-status (track calls :update)]
       (try
         (sync-user test-app

--- a/test/org/zalando/stups/mint/worker/test_helpers.clj
+++ b/test/org/zalando/stups/mint/worker/test_helpers.clj
@@ -32,11 +32,6 @@
   [coll]
   `(nth ~coll 2))
 
-(defmacro fourth
-  "Just as first, second, third"
-  [coll]
-  `(nth ~coll 3))
-
 (defn sequentially
   "Returns a function that returns provided arguments sequentially on every call"
   [& args]

--- a/test/org/zalando/stups/mint/worker/test_helpers.clj
+++ b/test/org/zalando/stups/mint/worker/test_helpers.clj
@@ -32,6 +32,11 @@
   [coll]
   `(nth ~coll 2))
 
+(defmacro fourth
+  "Just as first, second, third"
+  [coll]
+  `(nth ~coll 3))
+
 (defn sequentially
   "Returns a function that returns provided arguments sequentially on every call"
   [& args]


### PR DESCRIPTION
This is the first step to address #33

It solves the issue that S3 related code was used directly everywhere making it
hard to use another bucket storage service in place of S3 e.i. Google Cloud
Storage.

To solve this I have defined a protocol `BucketStorage` and used this protocol
wherever s3 functions was previously called directly in the code. I have also
changed the `S3Exception` to the more general name `StorageException`.

This PR only implements the s3 version of `BucketStorage` so it will work like
before. I would like to get this reviewed before providing the Google Cloud
Storage implementation in another PR.

It does not deal with how we determine if a bucket is in s3 or in another
service. I would also like to discuss this (can move it to a separate issue if
you prefer).

The easiest solution would be to just derive the bucket type from the bucket
name, but a more robust solution would probably be to add a flag to the mint
storage defining what service the bucket belongs to.

What do you think about this?

Lastly regarding the Google Cloud Storage integration. As I understand from
working on this, it will cause problems (racing) if you were to run mint-worker
in AWS and GCP at the same time. Do you have any idea how we could solve that
issue?
One solution could be to just run the worker in AWS and then setup a proxy in
GCP that can deal with the bucket permissions for google cloud storage, but
it's possible not the best solution and I would like to hear your opinion on
this matter.
