### PR TITLE
#33 Implement Google Cloud Storage interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ JOBS_KIO_URL            | yes        |                         | URL to [Kio](ht
 JOBS_SERVICE_USER_URL   | yes        |                         | URL to Service User API
 JOBS_MINT_STORAGE_URL   | yes        |                         | URL to Mint storage
 JOBS_ESSENTIALS_URL     | yes        |                         | URL of [essentials](https://github.com/zalando-stups/essentials). Used to verify scopes.
-JOBS_MINT_COWORKER_URL  | no         |                         | URL of [mint-coworker proxy](https://github.bus.zalan.do/teapot/mint-coworker). Used for proxying bucket writes to GCS.
+JOBS_MINT_COWORKER_URL  | no         |                         | URL of [mint-coworker proxy](deps/mint-coworker.yaml). Used for proxying bucket writes to GCS.
 JOBS_MAX_S3_ERRORS      | no         | 10                      | At which point mint-worker pauses password/client rotation for applications
 JOBS_ETCD_LOCK_URL      | no         |                         | etcd key URL for locking
 JOBS_ETCD_LOCK_TTL      | no         | 500                     | etcd TTL for locking

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ JOBS_KIO_URL            | yes        |                         | URL to [Kio](ht
 JOBS_SERVICE_USER_URL   | yes        |                         | URL to Service User API
 JOBS_MINT_STORAGE_URL   | yes        |                         | URL to Mint storage
 JOBS_ESSENTIALS_URL     | yes        |                         | URL of [essentials](https://github.com/zalando-stups/essentials). Used to verify scopes.
+JOBS_MINT_COWORKER_URL  | no         |                         | URL of [mint-coworker proxy](https://github.bus.zalan.do/teapot/mint-coworker). Used for proxying bucket writes to GCS.
 JOBS_MAX_S3_ERRORS      | no         | 10                      | At which point mint-worker pauses password/client rotation for applications
 JOBS_ETCD_LOCK_URL      | no         |                         | etcd key URL for locking
 JOBS_ETCD_LOCK_TTL      | no         | 500                     | etcd TTL for locking
@@ -65,7 +66,7 @@ development:
 
 ## License
 
-Copyright © 2015 Zalando SE
+Copyright © 2016 Zalando SE
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/deps/mint-coworker.yaml
+++ b/deps/mint-coworker.yaml
@@ -1,0 +1,68 @@
+swagger: "2.0"
+
+info:
+  version: "0.0.1"
+  title: Mint Coworker
+  description: Mint Coworker is a proxy for mint worker
+
+schemes:
+    - "https"
+basePath: /v1
+produces:
+  - application/json
+consumes:
+  - application/json
+
+security:
+  - oauth2: [uid]
+
+paths:
+  /{bucket}/{path}:
+    post:
+      summary: Store object in bucket at path
+      description: |
+        Store an object in a bucket at the specified path.
+      operationId: storeObject
+      tags:
+        - buckets
+      consumes:
+        - application/octet-stream
+      parameters:
+        - $ref: "#/parameters/bucket"
+        - $ref: "#/parameters/path"
+        - name: data
+          in: body
+          required: true
+          schema:
+            description: binary
+            type: string
+            format: byte
+      responses:
+        204:
+          description: object was successfully stored
+        404:
+          description: bucket was not found or unauthorized
+
+parameters:
+  bucket:
+    name: bucket
+    in: path
+    type: string
+    description: bucket name
+    required: true
+    pattern: "^[a-z][a-z0-9-_.]*[a-z0-9]$"
+  path:
+    name: path
+    in: path
+    type: string
+    description: object path
+    required: true
+    pattern: "^.{1,1024}$"
+
+securityDefinitions:
+  oauth2:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://auth.zalando.com/z/oauth2/
+    scopes:
+      uid: Unique identifier of the user accessing the service.

--- a/src/org/zalando/stups/mint/worker/core.clj
+++ b/src/org/zalando/stups/mint/worker/core.clj
@@ -34,6 +34,7 @@
                                                               :tokens        {:mint-storage-rw-api ["uid" "application.write_all_sensitive"]
                                                                               :kio-ro-api          ["uid"]
                                                                               :service-user-rw-api ["uid"]
+                                                                              :mint-coworker-w-api ["uid"]
                                                                               :essentials-ro-api   ["uid"]}})
                  :jobs (using (job/map->Jobs {:configuration (:jobs configuration)})
                               [:tokens]))]

--- a/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/bucket_storage.clj
@@ -15,14 +15,14 @@
 
 (defmulti writable?
           "Check if a bucket is writable?"
-          (fn [bucket-name app-id &] (infer-bucket-type bucket-name)))
+          (fn [bucket-name app-id & _] (infer-bucket-type bucket-name)))
 
 (defmulti save-user
           "Save user credentials in bucket"
-          (fn [bucket-name app-id username password &]
+          (fn [bucket-name app-id username password & _]
             (infer-bucket-type bucket-name)))
 
 (defmulti save-client
           "Save client credentials in bucket"
-          (fn [bucket-name app-id client-id client-secret &]
+          (fn [bucket-name app-id client-id client-secret & _]
             (infer-bucket-type bucket-name)))

--- a/src/org/zalando/stups/mint/worker/external/gcs.clj
+++ b/src/org/zalando/stups/mint/worker/external/gcs.clj
@@ -1,0 +1,71 @@
+(ns org.zalando.stups.mint.worker.external.gcs
+  (:require [org.zalando.stups.friboo.ring :refer [conpath]]
+            [org.zalando.stups.friboo.log :as log]
+            [org.zalando.stups.friboo.config :as config]
+            [clojure.string :as str]
+            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [writable?
+                                                                           save-user
+                                                                           save-client
+                                                                           StorageException]]
+            [org.zalando.stups.friboo.system.oauth2 :as oauth2]))
+
+(defn post-object
+  "POST /{bucket}/{path}"
+  [mint-coworker-url bucket-name path data tokens]
+  (client/post (conpath mint-coworker-url bucket-name path)
+               {:oauth-token  (oauth2/access-token :mint-coworker-w-api tokens)
+                :content-type :json
+                :form-params  data
+                :as           :json}))
+
+(defmethod writable? :gs [bucket-name app-id configuration tokens]
+  {:pre [(not (str/blank? bucket-name))
+         (not (str/blank? app-id))]}
+  (let [mint-coworker-url (config/require-config configuration :mint-coworker-url)
+        bucket-name (str/replace bucket-name #"^gs://" "")]
+    (try
+      (post-object mint-coworker-url
+                   bucket-name
+                   (str app-id "/test-mint-write")
+                   {:status "SUCCESS"}
+                   tokens)
+      (log/debug "Bucket %s with prefix %s is writable" bucket-name app-id)
+      true
+      (catch Exception e
+        (log/debug "Bucket %s with prefix %s is NOT WRITABLE. Reason %s." bucket-name app-id (str e))
+        false))))
+
+(defmethod save-user :gs [bucket-name app-id username password configuration tokens]
+  {:pre [(not (str/blank? bucket-name))
+         (not (str/blank? app-id))]}
+  (let [mint-coworker-url (config/require-config configuration :mint-coworker-url)
+        bucket-name (str/replace bucket-name #"^gs://" "")]
+    (try
+      (post-object mint-coworker-url
+                   bucket-name
+                   (str app-id "/user.json")
+                   {:application_username username
+                    :application_password password}
+                   tokens)
+      (catch Exception e
+        (StorageException (.getMessage e)
+                     {:message (.getMessage e)
+                      :original e})))))
+
+(defmethod save-client :gs [bucket-name app-id client-id client-secret configuration tokens]
+  {:pre [(not (str/blank? bucket-name))
+         (not (str/blank? app-id))]}
+  (let [mint-coworker-url (config/require-config configuration :mint-coworker-url)
+        bucket-name (str/replace bucket-name #"^gs://" "")]
+    (try
+      (post-object mint-coworker-url
+                   bucket-name
+                   (str app-id "/client.json")
+                   {:client_id client-id
+                    :client_secret client-secret}
+                   tokens)
+      (catch Exception e
+        (StorageException (.getMessage e)
+                     {:message (.getMessage e)
+                      :original e})))))

--- a/src/org/zalando/stups/mint/worker/external/s3.clj
+++ b/src/org/zalando/stups/mint/worker/external/s3.clj
@@ -40,7 +40,7 @@
       (.setRegion s3client region))
     (.putObject s3client request)))
 
-(defmethod writable? :s3 [bucket-name app-id]
+(defmethod writable? :s3 [bucket-name app-id & _]
   {:pre [(not (str/blank? bucket-name))
          (not (str/blank? app-id))]}
   (try
@@ -53,7 +53,7 @@
       (log/debug "S3 bucket %s with prefix %s is NOT WRITABLE. Reason %s." bucket-name app-id (str e))
       false)))
 
-(defmethod save-user :s3 [bucket-name app-id username password]
+(defmethod save-user :s3 [bucket-name app-id username password & _]
   {:pre [(not (str/blank? bucket-name))
          (not (str/blank? app-id))]}
   (try
@@ -67,7 +67,7 @@
                          :message  (.getMessage e)
                          :original e}))))
 
-(defmethod save-client :s3 [bucket-name app-id client-id client-secret]
+(defmethod save-client :s3 [bucket-name app-id client-id client-secret & _]
   {:pre [(not (str/blank? bucket-name))
          (not (str/blank? app-id))]}
   (try

--- a/src/org/zalando/stups/mint/worker/job/run.clj
+++ b/src/org/zalando/stups/mint/worker/job/run.clj
@@ -7,6 +7,7 @@
             [org.zalando.stups.mint.worker.external.apps :as apps]
             [org.zalando.stups.mint.worker.external.etcd :as etcd]
             [org.zalando.stups.mint.worker.external.s3]
+            [org.zalando.stups.mint.worker.external.gcs]
             [org.zalando.stups.mint.worker.external.bucket_storage :refer [storage-exception?]]
             [overtone.at-at :refer [every]]
             [clj-time.core :as time]))

--- a/src/org/zalando/stups/mint/worker/job/sync_app.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_app.clj
@@ -20,7 +20,7 @@
     (if-not (> s3_errors
                max-s3-errors)
             (let [app        (storage/get-app storage-url id tokens)
-                  unwritable (doall (remove #(writable? % id) (:s3_buckets app)))]
+                  unwritable (doall (remove #(writable? % id configuration tokens) (:s3_buckets app)))]
               (if (seq unwritable)
                   ; unwritable buckets! skip sync.
                   (do

--- a/src/org/zalando/stups/mint/worker/job/sync_client.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_client.clj
@@ -29,7 +29,7 @@
                 client-secret (:client_secret generate-client-response)]
             ; Step 2: distribute it
             (log/debug "Saving the new client for %s to buckets: %s..." id s3_buckets)
-            (if-let [error (c/has-error (c/busy-map #(save-client % id new-client-id client-secret)
+            (if-let [error (c/has-error (c/busy-map #(save-client % id new-client-id client-secret configuration tokens)
                                                     s3_buckets))]
               (do
                 (log/debug "Could not save client to bucket: %s" (str error))

--- a/src/org/zalando/stups/mint/worker/job/sync_password.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_password.clj
@@ -26,7 +26,7 @@
         (let [{:keys [password txid]} (services/generate-new-password service-user-url username tokens)]
           ; Step 2: distribute it
           (log/debug "Saving the new password for %s to buckets: %s..." id s3_buckets)
-          (if-let [error (c/has-error (c/busy-map #(save-user % id username password)
+          (if-let [error (c/has-error (c/busy-map #(save-user % id username password configuration tokens)
                                                   s3_buckets))]
             (do
               (log/debug "Could not save password to bucket: %s" (str error))

--- a/src/org/zalando/stups/mint/worker/job/sync_user.clj
+++ b/src/org/zalando/stups/mint/worker/job/sync_user.clj
@@ -62,7 +62,7 @@
             (when (and (not is_client_confidential)
                        (nil? client_id))
               (log/debug "Saving non-confidential client ID %s for app %s..." new-client-id id)
-              (when-let [error (c/has-error (c/busy-map #(save-client % id new-client-id nil)
+              (when-let [error (c/has-error (c/busy-map #(save-client % id new-client-id nil configuration tokens)
                                                         s3_buckets))]
                 (log/debug "Could not save client ID: %s" (str error))
                 ; throw to update s3_errors once outside

--- a/test/org/zalando/stups/mint/worker/external/gcs_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/gcs_test.clj
@@ -1,0 +1,46 @@
+(ns org.zalando.stups.mint.worker.external.gcs-test
+  (:require [clojure.test :refer :all]
+            [org.zalando.stups.mint.worker.external.gcs :as gcs]
+            [org.zalando.stups.mint.worker.external.bucket_storage :refer [save-client
+                                                                           save-user
+                                                                           writable?]]
+            [org.zalando.stups.mint.worker.test-helpers :refer [test-tokens
+                                                                test-config]]))
+
+(defn mock-put-error
+  [& args]
+  (throw (Exception. "ohmigods")))
+
+(deftest mint-coworker-writable-false
+  (with-redefs [gcs/post-object mock-put-error]
+    (is (= (writable? "gs://bucket" "app" test-config test-tokens)
+           false))))
+
+(deftest mint-coworker-writable-false
+  (with-redefs [gcs/post-object (constantly nil)]
+    (is (= (writable? "gs://bucket" "app" test-config test-tokens)
+           true))))
+
+(deftest mint-coworker-save-client-fail
+ (with-redefs [gcs/post-object mock-put-error]
+   (let [error (save-client "gs://bucket" "app" "client" "secret"
+                            test-config test-tokens)]
+     (is (= (:type (ex-data error))
+            "StorageException")))))
+
+(deftest mint-coworker-save-client-success
+  (with-redefs [gcs/post-object (constantly nil)]
+   (is (nil? (save-client "gs://bucket" "app" "client" "secret"
+                          test-config test-tokens)))))
+
+(deftest mint-coworker-save-user-fail
+ (with-redefs [gcs/post-object mock-put-error]
+   (let [error (save-user "gs://bucket" "app" "name" "password"
+                          test-config test-tokens)]
+     (is (= (:type (ex-data error))
+            "StorageException")))))
+
+(deftest mint-coworker-save-user-success
+  (with-redefs [gcs/post-object (constantly nil)]
+   (is (nil? (save-client "gs://bucket" "app" "name" "password"
+                          test-config test-tokens)))))

--- a/test/org/zalando/stups/mint/worker/test_helpers.clj
+++ b/test/org/zalando/stups/mint/worker/test_helpers.clj
@@ -1,13 +1,14 @@
 (ns org.zalando.stups.mint.worker.test-helpers)
 
 (def test-config
-  {:storage-url      "https://localhost"
-   :kio-url          "https://localhost"
-   :service-user-url "https://localhost"
-   :mint-storage-url "https://localhost"
-   :essentials-url   "https://localhost"
-   :prefix           "stups_"
-   :max-s3-errors    10})
+  {:storage-url       "https://localhost"
+   :kio-url           "https://localhost"
+   :service-user-url  "https://localhost"
+   :mint-storage-url  "https://localhost"
+   :essentials-url    "https://localhost"
+   :mint-coworker-url "https://localhost"
+   :prefix            "stups_"
+   :max-s3-errors     10})
 
 (def test-tokens
   {})


### PR DESCRIPTION
This is a followup to #39

It implements an interface for writing to Google Cloud Storage buckets through a proxy that runs in GCP and handles the bucket permissions.

A compatiable proxy is implemented in [mint-coworker](https://github.bus.zalan.do/teapot/mint-coworker) (GHE) which also has the simple API defined in the [swagger spec](https://github.bus.zalan.do/teapot/mint-coworker/blob/master/docs/swagger.yaml)

I guess it would make sense to move this proxy project to github.com under the `zalando-stups` Org? @LappleApple what's your opinion on that?

Here's a rough sketch of the system layout with this PR and proxy in place:

![mint-worker](https://cloud.githubusercontent.com/assets/128566/18436719/fd02e4c0-78f9-11e6-978c-439b902cbef6.png)

And the way it will work is, you just prefix your bucket name with `gs://` in yourturn and mint-worker will write credentials to the GCS bucket through the mint-coworker proxy. If the bucketname isn't prefixed with `gs://` it will assume it's an S3 bucket and behave the same as before.

Close #33
