### PR TITLE
Set HTTP timeouts

### DIFF
--- a/src/org/zalando/stups/mint/worker/external/apps.clj
+++ b/src/org/zalando/stups/mint/worker/external/apps.clj
@@ -1,6 +1,6 @@
 (ns org.zalando.stups.mint.worker.external.apps
   (:require [org.zalando.stups.friboo.ring :refer [conpath]]
-            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [clojure.string :as str]))
 

--- a/src/org/zalando/stups/mint/worker/external/etcd.clj
+++ b/src/org/zalando/stups/mint/worker/external/etcd.clj
@@ -1,5 +1,5 @@
 (ns org.zalando.stups.mint.worker.external.etcd
-  (:require [clj-http.client :as client]
+  (:require [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.friboo.log :as log]))
 
 (defn refresh-lock

--- a/src/org/zalando/stups/mint/worker/external/gcs.clj
+++ b/src/org/zalando/stups/mint/worker/external/gcs.clj
@@ -3,7 +3,7 @@
             [org.zalando.stups.friboo.log :as log]
             [org.zalando.stups.friboo.config :as config]
             [clojure.string :as str]
-            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.mint.worker.external.bucket_storage :refer [writable?
                                                                            save-user
                                                                            save-client

--- a/src/org/zalando/stups/mint/worker/external/http.clj
+++ b/src/org/zalando/stups/mint/worker/external/http.clj
@@ -2,8 +2,8 @@
   (:require [clj-http.client :as client]))
 
 (def ^:private default-http-options
-  {:socket-timeout 10000
-   :conn-timeout 10000})
+  {:socket-timeout 60000
+   :conn-timeout 60000})
 
 (defn get [url & [options]]
   (client/get url (merge default-http-options (or options {}))))

--- a/src/org/zalando/stups/mint/worker/external/http.clj
+++ b/src/org/zalando/stups/mint/worker/external/http.clj
@@ -6,16 +6,16 @@
    :conn-timeout 1000})
 
 (defn get [url & [options]]
-  (client/get url (merge default-http-options options)))
+  (client/get url (merge default-http-options (or options {}))))
 
 (defn post [url & [options]]
-  (client/post url (merge default-http-options options)))
+  (client/post url (merge default-http-options (or options {}))))
 
 (defn patch [url & [options]]
-  (client/patch url (merge default-http-options options)))
+  (client/patch url (merge default-http-options (or options {}))))
 
 (defn put [url & [options]]
-  (client/put url (merge default-http-options options)))
+  (client/put url (merge default-http-options (or options {}))))
 
 (defn delete [url & [options]]
-  (client/delete url (merge default-http-options options)))
+  (client/delete url (merge default-http-options (or options {}))))

--- a/src/org/zalando/stups/mint/worker/external/http.clj
+++ b/src/org/zalando/stups/mint/worker/external/http.clj
@@ -2,8 +2,8 @@
   (:require [clj-http.client :as client]))
 
 (def ^:private default-http-options
-  {:socket-timeout 1000
-   :conn-timeout 1000})
+  {:socket-timeout 10000
+   :conn-timeout 10000})
 
 (defn get [url & [options]]
   (client/get url (merge default-http-options (or options {}))))

--- a/src/org/zalando/stups/mint/worker/external/http.clj
+++ b/src/org/zalando/stups/mint/worker/external/http.clj
@@ -1,0 +1,21 @@
+(ns org.zalando.stups.mint.worker.external.http
+  (:require [clj-http.client :as client]))
+
+(def ^:private default-http-options
+  {:socket-timeout 1000
+   :conn-timeout 1000})
+
+(defn get [url & [options]]
+  (client/get url (merge default-http-options options)))
+
+(defn post [url & [options]]
+  (client/post url (merge default-http-options options)))
+
+(defn patch [url & [options]]
+  (client/patch url (merge default-http-options options)))
+
+(defn put [url & [options]]
+  (client/put url (merge default-http-options options)))
+
+(defn delete [url & [options]]
+  (client/delete url (merge default-http-options options)))

--- a/src/org/zalando/stups/mint/worker/external/scopes.clj
+++ b/src/org/zalando/stups/mint/worker/external/scopes.clj
@@ -1,6 +1,6 @@
 (ns org.zalando.stups.mint.worker.external.scopes
   (:require [org.zalando.stups.friboo.ring :refer [conpath]]
-            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [clojure.string :as str]))
 

--- a/src/org/zalando/stups/mint/worker/external/services.clj
+++ b/src/org/zalando/stups/mint/worker/external/services.clj
@@ -1,6 +1,6 @@
 (ns org.zalando.stups.mint.worker.external.services
   (:require [org.zalando.stups.friboo.ring :refer [conpath]]
-            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [clojure.string :as str]))
 

--- a/src/org/zalando/stups/mint/worker/external/storage.clj
+++ b/src/org/zalando/stups/mint/worker/external/storage.clj
@@ -1,6 +1,6 @@
 (ns org.zalando.stups.mint.worker.external.storage
   (:require [org.zalando.stups.friboo.ring :refer [conpath]]
-            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [clojure.string :as str]))
 

--- a/test/org/zalando/stups/mint/worker/external/etcd_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/etcd_test.clj
@@ -1,6 +1,6 @@
 (ns org.zalando.stups.mint.worker.external.etcd-test
   (:require [clojure.test :refer :all]
-            [clj-http.client :as client]
+            [org.zalando.stups.mint.worker.external.http :as client]
             [org.zalando.stups.mint.worker.external.etcd :as etcd]))
 
 (defn mock-put-error

--- a/test/org/zalando/stups/mint/worker/external/http_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/http_test.clj
@@ -5,8 +5,8 @@
             [org.zalando.stups.mint.worker.external.http :as client]))
 
 (def expected-default-options
-  {:socket-timeout 10000
-   :conn-timeout 10000})
+  {:socket-timeout 60000
+   :conn-timeout 60000})
 
 (deftest test-http-wrapper
 

--- a/test/org/zalando/stups/mint/worker/external/http_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/http_test.clj
@@ -4,6 +4,10 @@
             [clj-http.client :as clj-http]
             [org.zalando.stups.mint.worker.external.http :as client]))
 
+(def expected-default-options
+  {:socket-timeout 10000
+   :conn-timeout 10000})
+
 (deftest test-http-wrapper
 
   (testing "http options are merged with default"
@@ -15,8 +19,7 @@
           (is
             (=
               (second (first (:get @calls)))
-              {:socket-timeout 1000
-               :conn-timeout 1000}))))
+              expected-default-options))))
 
      (testing "put"
        (let [calls (atom {})]
@@ -25,8 +28,7 @@
            (is
              (=
                (second (first (:put @calls)))
-               {:socket-timeout 1000
-                :conn-timeout 1000}))))
+               expected-default-options))))
 
       (testing "patch"
         (let [calls (atom {})]
@@ -35,8 +37,7 @@
             (is
               (=
                 (second (first (:patch @calls)))
-                {:socket-timeout 1000
-                 :conn-timeout 1000}))))
+                expected-default-options))))
 
 
        (testing "post"
@@ -46,8 +47,7 @@
              (is
                (=
                  (second (first (:post @calls)))
-                 {:socket-timeout 1000
-                  :conn-timeout 1000}))))
+                 expected-default-options))))
 
         (testing "delete"
           (let [calls (atom {})]
@@ -56,5 +56,4 @@
               (is
                 (=
                   (second (first (:delete @calls)))
-                  {:socket-timeout 1000
-                   :conn-timeout 1000})))))))))))
+                  expected-default-options)))))))))))

--- a/test/org/zalando/stups/mint/worker/external/http_test.clj
+++ b/test/org/zalando/stups/mint/worker/external/http_test.clj
@@ -1,0 +1,60 @@
+(ns org.zalando.stups.mint.worker.external.http-test
+  (:require [clojure.test :refer :all]
+            [org.zalando.stups.mint.worker.test-helpers :as u]
+            [clj-http.client :as clj-http]
+            [org.zalando.stups.mint.worker.external.http :as client]))
+
+(deftest test-http-wrapper
+
+  (testing "http options are merged with default"
+
+    (testing "get"
+      (let [calls (atom {})]
+        (with-redefs [clj-http/get (u/track calls :get)]
+          (client/get "localhost.com" {})
+          (is
+            (=
+              (second (first (:get @calls)))
+              {:socket-timeout 1000
+               :conn-timeout 1000}))))
+
+     (testing "put"
+       (let [calls (atom {})]
+         (with-redefs [clj-http/put (u/track calls :put)]
+           (client/put "localhost.com" {})
+           (is
+             (=
+               (second (first (:put @calls)))
+               {:socket-timeout 1000
+                :conn-timeout 1000}))))
+
+      (testing "patch"
+        (let [calls (atom {})]
+          (with-redefs [clj-http/patch (u/track calls :patch)]
+            (client/patch "localhost.com" {})
+            (is
+              (=
+                (second (first (:patch @calls)))
+                {:socket-timeout 1000
+                 :conn-timeout 1000}))))
+
+
+       (testing "post"
+         (let [calls (atom {})]
+           (with-redefs [clj-http/post (u/track calls :post)]
+             (client/post "localhost.com" {})
+             (is
+               (=
+                 (second (first (:post @calls)))
+                 {:socket-timeout 1000
+                  :conn-timeout 1000}))))
+
+        (testing "delete"
+          (let [calls (atom {})]
+            (with-redefs [clj-http/delete (u/track calls :delete)]
+              (client/delete "localhost.com" {})
+              (is
+                (=
+                  (second (first (:delete @calls)))
+                  {:socket-timeout 1000
+                   :conn-timeout 1000})))))))))))


### PR DESCRIPTION
Fixes #32 

Sets both connection and socket timeout to 10 seconds (please advise if other value is better). Hope hardcoded value is ok.

Apache HTTP Client version in mint-worker (@jbellmann's comment) should be fine, is `4.5.1`.